### PR TITLE
Updated material-ui to version 0.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "babelify": "^6.2.0",
     "browserify": "^11.0.1",
-    "material-ui": "^0.10.4",
+    "material-ui": "0.12.2",
     "react": "^0.13.3",
     "react-tap-event-plugin": "^0.1.7"
   },


### PR DESCRIPTION
:rocket:

material-ui just published version 0.12.2, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
[GitHub Release](https://github.com/callemall/material-ui/releases/tag/v0.12.2)

##### General
- NEW GridList component and documentation! Thanks to @igorbt (#1320)

##### Component Fixes / Enhancements
- Added back canvasColor to theme palette (#1762)
- Added hintStyle prop to TextField (#1510)
- Add isScrollbarVisible function to table (#1539)
- Add rowsMax prop to EnhancedTextarea (#1562)
- Tab "item three" renamed on docs site (#1775)
- Fixed docs server to run on Windows (#1774)
- FlatButton now has a backgroundColor prop (#1561)
- Fixed DropdownMenu buggy value prop check (#1768)

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>